### PR TITLE
BBL-381 | Standalone makefile approach implemented and tested + READM…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ init-makefiles: ## initialize makefiles
 ## IMPORTANT: Automatically managed
 ## Must NOT UNCOMMENT the #include lines below
 #
-#include ${MAKEFILES_DIR}/circleci/circleci.mk
-#include ${MAKEFILES_DIR}/release-mgmt/release.mk
-#include ${MAKEFILES_DIR}/terraform12/terraform12.mk
-#include ${MAKEFILES_DIR}/terratest12/terratest12.mk
+include ${MAKEFILES_DIR}/circleci/circleci.mk
+include ${MAKEFILES_DIR}/release-mgmt/release.mk
+include ${MAKEFILES_DIR}/terraform12/terraform12.mk
+include ${MAKEFILES_DIR}/terratest12/terratest12.mk
+

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ init-makefiles: ## initialize makefiles
 ## IMPORTANT: Automatically managed
 ## Must NOT UNCOMMENT the #include lines below
 #
-include ${MAKEFILES_DIR}/circleci/circleci.mk
-include ${MAKEFILES_DIR}/release-mgmt/release.mk
-include ${MAKEFILES_DIR}/terraform12/terraform12.mk
-include ${MAKEFILES_DIR}/terratest12/terratest12.mk
-
+#include ${MAKEFILES_DIR}/circleci/circleci.mk
+#include ${MAKEFILES_DIR}/release-mgmt/release.mk
+#include ${MAKEFILES_DIR}/terraform12/terraform12.mk
+#include ${MAKEFILES_DIR}/terratest12/terratest12.mk

--- a/README.md
+++ b/README.md
@@ -12,6 +12,43 @@
 ## Overview
 Terraform module to provision AWS Backup. At the moment of this modules creation, there were only 2 modules that offered a similar functionality, the only difference was that they only allowed to pass specific resource IDs. This module allows the use of tags to define which resources are selected for backups.
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.28 |
+| aws | >= 2.70.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 2.70.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| name | Solution name, e.g. 'app' or 'cluster' | `string` | n/a | yes |
+| selection\_by\_tags | A map that defines the key/value pairs that will be used for backup resources selection | `map` | n/a | yes |
+| cold\_storage\_after | Specifies the number of days after creation that a recovery point is moved to cold storage | `number` | `null` | no |
+| completion\_window | The amount of time AWS Backup attempts a backup before canceling the job and returning an error. Must be at least 60 minutes greater than `start_window` | `number` | `null` | no |
+| delete\_after | Specifies the number of days after creation that a recovery point is deleted. Must be 90 days greater than `cold_storage_after` | `number` | `null` | no |
+| kms\_key\_arn | The server-side encryption key that is used to protect your backups | `string` | `null` | no |
+| schedule | A CRON expression specifying when AWS Backup initiates a backup job | `string` | `null` | no |
+| start\_window | The amount of time in minutes before beginning a backup. Minimum value is 60 minutes | `number` | `null` | no |
+| tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
+| vault\_name | The name of the Backup Vault that will be associated to the Backup Plan | `string` | `"Default"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| backup\_plan\_arn | Backup Plan ARN |
+| backup\_plan\_version | Unique, randomly generated, Unicode, UTF-8 encoded string that serves as the version ID of the backup plan |
+| backup\_selection\_id | Backup Selection ID |
+
+
 ## Roadmap
 * Improve documentation
 * Add support to create/use a different Backup Vault

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+
+terraform {
+  required_version = ">= 0.12.28"
+
+  required_providers {
+    aws   = ">= 2.70.0"
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,6 +3,6 @@ terraform {
   required_version = ">= 0.12.28"
 
   required_providers {
-    aws   = ">= 2.70.0"
+    aws = ">= 2.70.0"
   }
 }


### PR DESCRIPTION
### What?
#### Commits on Sep 17, 2020
- @exequielrafaela - BBL-381 | Standalone makefile approach implemented and tested + README.md w/ versions.tf updated - ca97fb2

### Why? 
[BBL-381 | [ref-architecture-terraform] Makefiles + Scripts | migrate /@bin to an stand-alone repo to grant reusability #124](https://trello.com/c/XZSiNWFB/381-bbl-381-ref-architecture-terraform-makefiles-scripts-migrate-bin-to-an-stand-alone-repo-to-grant-reusability-124)