### PR TITLE
BBL-381 | adding makefile related doc to readme.md + ci job aws cred …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,10 @@ jobs:
       - run:
           name: Configure awscli
           command: |
+            # AWS credentials dir
+            mkdir --parents /home/circleci/.aws/bb
+            sudo chown -R $USER:$USER /home/circleci/.aws
+
             # AWS defautl awscli profile
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
             aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
@@ -45,8 +49,8 @@ jobs:
             # AWS dev awscli profile
             aws configure set role_arn arn:aws:iam::$AWS_ACCOUNT_ID_DEV:role/DeployMaster --profile $AWS_PROFILE_NAME
             aws configure set source_profile default --profile $AWS_PROFILE_NAME
+
             # moving credentials to specific project folder
-            mkdir --parents /home/circleci/.aws/bb
             cp /home/circleci/.aws/credentials /home/circleci/.aws/bb/credentials
             cp /home/circleci/.aws/config /home/circleci/.aws/bb/config
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,49 @@
 # Terraform Module: AWS Backup By Tags
 
 ## Overview
-Terraform module to provision AWS Backup. At the moment of this modules creation, there were only 2 modules that offered a similar functionality, the only difference was that they only allowed to pass specific resource IDs. This module allows the use of tags to define which resources are selected for backups.
+Terraform module to provision AWS Backup. At the moment of this modules creation, there were only 2 modules that
+offered a similar functionality, the only difference was that they only allowed to pass specific resource IDs.
+This module allows the use of tags to define which resources are selected for backups.
+
+## Pre-Requirements
+
+In order to get the full automated potential of the
+[Binbash Leverage DevOps Automation Code Library](https://leverage.binbash.com.ar/how-it-works/code-library/code-library/)  
+you should initialize all the necessary helper **Makefiles**. 
+
+#### How? 
+You must execute the `make init-makefiles` command  at the root context
+
+     
+```shell
+╭─delivery at delivery-I7567 in ~/terraform/terraform-aws-backup-by-tags on master✔ 20-09-17
+╰─⠠⠵ make
+Available Commands:
+ - init-makefiles     initialize makefiles
+
+``` 
+
+### Why? 
+You'll get all the necessary commands to automatically operate this module via a dockerized approach, 
+example shown below
+
+```shell
+╭─delivery at delivery-I7567 in ~/terraform/terraform-aws-backup-by-tags on master✔ 20-09-17
+╰─⠠⠵ make
+Available Commands:
+ - circleci-validate-config  ## Validate A CircleCI Config (https
+ - format-check        ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
+ - format              ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
+ - tf-dir-chmod        ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+ - version             ## Show terraform version
+ - init-makefiles      ## initialize makefiles
+``` 
+
+```shell
+╭─delivery at delivery-I7567 in ~/terraform/terraform-aws-backup-by-tags on master✔ 20-09-17
+╰─⠠⠵ make format-check 
+docker run --rm -v /home/delivery/Binbash/repos/Leverage/terraform/terraform-aws-backup-by-tags:"/go/src/project/":rw -v :/config -v /common.config:/common-config/common.config -v ~/.ssh:/root/.ssh -v ~/.gitconfig:/etc/gitconfig -v ~/.aws/bb:/root/.aws/bb -e AWS_SHARED_CREDENTIALS_FILE=/root/.aws/bb/credentials -e AWS_CONFIG_FILE=/root/.aws/bb/config --entrypoint=/bin/terraform -w "/go/src/project/" -it binbash/terraform-awscli-slim:0.12.28 fmt -check
+```
 
 ## Requirements
 
@@ -50,7 +92,6 @@ Terraform module to provision AWS Backup. At the moment of this modules creation
 
 
 ## Roadmap
-* Improve documentation
 * Add support to create/use a different Backup Vault
 * Handle conditional backup selection by resource IDs
 


### PR DESCRIPTION
### Commits on Sep 17, 2020
- @exequielrafaela - BBL-381 | adding makefile related doc to readme.md + ci job aws cred mgmt improvement - 24ea018

### Why? 
[BBL-381 | [ref-architecture-terraform] Makefiles + Scripts | migrate /@bin to an stand-alone repo to grant reusability #124](https://trello.com/c/XZSiNWFB/381-bbl-381-ref-architecture-terraform-makefiles-scripts-migrate-bin-to-an-stand-alone-repo-to-grant-reusability-124)